### PR TITLE
Use heic-convert npm package to process images

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ permissions first, rather than later in the route code itself.
 
 ## Changelog
 
-1.1.0: Use [heic-convert](https://github.com/catdad-experiments/heic-convert) in replacement of [tifig](https://github.com/monostream/tifig).
+2.0.0: Use [heic-convert](https://github.com/catdad-experiments/heic-convert) in replacement of [tifig](https://github.com/monostream/tifig).
 
 1.0.2: supports more types of file upload middleware. In particular, the sub-objects of `req.files` may be arrays, and if `path` does not have any extension to change then a `.jpg` extension is added.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ```javascript
 const multipart = require('connect-multiparty')();
-const heicToJpeg = require('heic-to-jpeg')(tifig: '/opt/tifig');
+const heicToJpeg = require('heic-to-jpeg')();
 const app = require('express')();
 app.post('/upload', multipart, heicToJpeg, function(req, res) {
   // Access req.files as you normally would here.
@@ -20,16 +20,6 @@ provides a `req.files` object in which each sub-object has
 `path`, `name` and `type` properties. The sub-objects of
 `req.files` may also be arrays of such objects.
 
-[Requires the "tifig" command line utility. Install
-that first.](https://github.com/monostream/tifig) You may specify its
-path via `options.tifig`. If not it is assumed to be in the `PATH`
-as `tifig`.
-
-## Limitations
-
-The `tifig` utility politely refuses to work on HEIF files
-that didn't come from iOS 11. This is not a bug in the middleware.
-
 ## Alternatives
 
 The very latest versions of ImageMagick support HEIF too.
@@ -37,15 +27,16 @@ The very latest versions of ImageMagick support HEIF too.
 ## Warnings
 
 To prevent a denial of service, middleware that does CPU- and RAM-intensive
-stuff like this should always be added only to the specific routes that 
+stuff like this should always be added only to the specific routes that
 require it. It's also a good idea to use other middleware to check the user's
 permissions first, rather than later in the route code itself.
 
 ## Changelog
+
+1.1.0: Use [heic-convert](https://github.com/catdad-experiments/heic-convert) in replacement of [tifig](https://github.com/monostream/tifig).
 
 1.0.2: supports more types of file upload middleware. In particular, the sub-objects of `req.files` may be arrays, and if `path` does not have any extension to change then a `.jpg` extension is added.
 
 1.0.1: more docs, repo push.
 
 1.0.0: initial release.
-

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-const se = require('shell-escape');
+const fs = require('fs');
+const cp = require('child_process');
 
 module.exports = function(options) {
   options = options || {};
@@ -7,7 +8,7 @@ module.exports = function(options) {
     'image/heif': 1,
     'image/heic': 1,
     'image/heif-sequence': 1,
-    'image/heic-sequence': 1  
+    'image/heic-sequence': 1
   };
   return function(req, res, next) {
     if (!req.files) {
@@ -25,6 +26,7 @@ module.exports = function(options) {
         }
       });
     });
+    const worker = cp.fork(`${__dirname}/worker.js`);
     Promise.all(relevant.map(file => {
       const newName = file.name.replace(/\.[^\.]+$/, '.jpg');
       let newPath = file.path.replace(/\.[^\.]+$/, '.jpg');
@@ -33,25 +35,29 @@ module.exports = function(options) {
       }
       const newType = 'image/jpeg';
       return new Promise((resolve, reject) => {
-        require('child_process').exec(se([ options.tifig, file.path, newPath ]), { encoding: 'utf8' }, function(error, stdout, stderr) {
-          if (error) {
-            console.log(stdout);
-            console.error(stderr);
-            return reject(error);
-          }
-          file.name = newName;
-          // Avoid leaking many megabytes of disk space
-          require('fs').unlinkSync(file.path);
-          file.path = newPath;
-          file.type = newType;
-          return resolve(true);
+        const errorHandler = (error) => {
+            console.error(error);
+            reject(error);
+        };
+        worker.once('message', (_message) => {
+            file.name = newName;
+            // Avoid leaking many megabytes of disk space
+            fs.unlinkSync(file.path);
+            file.path = newPath;
+            file.type = newType;
+            // Avoid listener collision
+            worker.removeListener('error', errorHandler);
+            resolve(true);
         });
+        worker.once('error', errorHandler);
+        worker.send({ inputPath: file.path, outputPath: newPath });
       });
     })).then(o => {
+      // Gracefully kill the child process
+      worker.send({ exit: true });
       return next();
     }).catch(e => {
       res.status(500).send('error');
     });
   }
 };
-

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ const cp = require('child_process');
 
 module.exports = function(options) {
   options = options || {};
-  options.tifig = options.tifig || 'tifig';
   const types = {
     'image/heif': 1,
     'image/heic': 1,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/boutell/heic-to-jpeg-middleware#readme",
   "dependencies": {
+    "heic-convert": "^1.2.2",
     "shell-escape": "^0.2.0"
   }
 }

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,17 @@
+const { promisify } = require('util');
+const fs = require('fs');
+const convert = require('heic-convert');
+
+process.on('message', async ({ inputPath, outputPath, exit }) => {
+    if (exit) {
+        process.exit(0);
+    }
+    const inputBuffer = await promisify(fs.readFile)(inputPath);
+    const outputBuffer = await convert({
+        buffer: inputBuffer, // the HEIC file buffer
+        format: 'JPEG',      // output format
+        quality: 1           // the jpeg compression quality, between 0 and 1
+    });
+    await promisify(fs.writeFile)(outputPath, outputBuffer);
+    process.send(inputPath);
+});


### PR DESCRIPTION
Spawn one child process per request and convert images sequentially, avoiding blocking the main thread.

Note that there are many possible ways to use child processes (worker.js instances) here:
- One worker per image
- A singleton worker shared across requests
- A worker pool.

In the end I ended up using _one worker per request_ because I think it's flexible enough to scale with the server load but without unnecessarily straining the cpu like _one worker per image_ would.

For a comparison of how those different approaches work (except for the worker pool) you can try the `benchmark_test.js` file on [this branch](https://github.com/glmaljkovich/heic-to-jpeg-middleware/blob/heic-convert-benchmark/benchmark_test.js) 

----
closes #2 